### PR TITLE
make a folder LaunchAgents

### DIFF
--- a/all/install_postgresql_mac_&_linux.md
+++ b/all/install_postgresql_mac_&_linux.md
@@ -18,6 +18,7 @@ brew install postgresql --with-python
 
 Quick activation:
 
+mkdir -p ~/Library/LaunchAgents
 ```
 ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
 launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist


### PR DESCRIPTION
I needed to make a folder before checking the activation code. It might be required for others in the installation process in Debian / Linux 16.04 (fresh installation of postgreSQL
 ln -s /usr/local/opt/postgresql/homebrew.mxcl.postgresql.plist ~/Library/LaunchAgents